### PR TITLE
feat: scroll shadows, show most recent belt path games by default

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,7 +35,7 @@ def _build_full_page_context(request: Request):
         "season": schedule.get_season_pretty(),
         "schedule": schedule,
         "next_bout": schedule.find_match(holder, schedule.from_date),
-        "belt_path": Schedule.find_belt_path(league_schedule),
+        "belt_path": reversed(Schedule.find_belt_path(league_schedule)),
     }
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -65,7 +65,27 @@ button {
                 width: 100%;
                 & > .games-row {
                     overflow-x: auto;
-                    width: 100%;
+                    flex-direction: row-reverse;
+                    background: 
+                        linear-gradient(to right, aliceblue, aliceblue),
+                        linear-gradient(to right, aliceblue, aliceblue),
+                    
+                        linear-gradient(to right, rgba(0,0,0,.25), rgba(240, 248, 255,0)),
+                        linear-gradient(to left, rgba(0,0,0,.25), rgba(240, 248, 255,0));   
+
+                    background-position: left center, right center, left center, right center;
+                    background-repeat: no-repeat;
+                    background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+                    
+                    /* Opera doesn't support this in the shorthand */
+                    background-attachment: local, local, scroll, scroll;
+
+                    & > :first-child {
+                        margin-right: auto;
+                    }
+                    & > :last-child {
+                        margin-left: auto;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Page now loads like this (scrolled to the right showing most recent belt path games, shadow indicating scrolling available):
![image](https://github.com/user-attachments/assets/5cfb1eb1-b6c1-46d9-9cc6-5ef802bf70ca)
